### PR TITLE
Avoid over-depend for library users

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -98,7 +98,6 @@ AC_SUBST(LIBOAUTH_LDFLAGS)
 
 
 dnl *** PKGconfig oauth.pc.in ***
-PC_REQ=""
 PC_LIB=""
 
 dnl *** configuration options ***
@@ -123,11 +122,11 @@ fi
 dnl ** check for libcurl
 AS_IF([test "${enable_libcurl}" != "no"], [
   PKG_CHECK_MODULES(CURL, libcurl,
-    [ AC_DEFINE(HAVE_CURL, 1) HAVE_CURL=1 PC_REQ="$PC_REQ libcurl" PC_LIB="$PC_LIB ${CURL_LIBS}" report_curl="libcurl" ] , 
+    [ AC_DEFINE(HAVE_CURL, 1) HAVE_CURL=1 PC_LIB="$PC_LIB`$PKG_CONFIG --static --libs libcurl` " report_curl="libcurl" ] ,
     [
       AC_CHECK_HEADERS(curl/curl.h)
       AC_CHECK_LIB([curl], [curl_global_init], 
-        [AC_DEFINE(HAVE_CURL, 1) HAVE_CURL=1 PC_REQ="$PC_REQ libcurl" PC_LIB="$PC_LIB -lcurl" report_curl="libcurl" ]
+        [AC_DEFINE(HAVE_CURL, 1) HAVE_CURL=1 PC_LIB="$PC_LIB-lcurl " report_curl="libcurl" ]
       )
     ]
   )
@@ -163,22 +162,28 @@ AS_IF([test "${enable_builtinhash}" = "yes"], [
     ])
 ], [
   AS_IF([test "${enable_nss}" = "yes"], [
-    PKG_CHECK_MODULES(NSS, nss, [ AC_DEFINE(USE_NSS, 1) USE_NSS=1 PC_REQ="$PC_REQ nss" ])
-    HASH_LIBS=${NSS_LIBS}
-    HASH_CFLAGS=${NSS_CFLAGS}
-    report_hash="NSS"
+    PKG_CHECK_MODULES(NSS, nss,
+      [ AC_DEFINE(USE_NSS, 1) USE_NSS=1 PC_LIB="$PC_LIB`$PKG_CONFIG --static --libs nss` "
+        HASH_LIBS=${NSS_LIBS}
+        HASH_CFLAGS=${NSS_CFLAGS}
+        report_hash="NSS" ])
   ], [
-    AC_CHECK_HEADERS(openssl/hmac.h)
-    if test -z "${HASH_LIBS}"; then
-    HASH_LIBS="-lcrypto"
-    fi
-    if test -z "${HASH_CFLAGS}"; then
-    HASH_CFLAGS=""
-    fi
-    report_hash="OpenSSL"
-    PC_LIB="$PC_LIB ${HASH_LIBS}"
-    PC_REQ="$PC_REQ libcrypto"
-    AC_MSG_NOTICE([
+    PKG_CHECK_MODULES(OPENSSL, libcrypto,
+      [ PC_LIB="$PC_LIB`$PKG_CONFIG --static --libs libcrypto` "
+        HASH_LIBS=${OPENSSL_LIBS}
+        HASH_CFLAGS=${OPENSSL_CFLAGS}
+        report_hash="OpenSSL" ] ,
+      [
+        AC_CHECK_HEADERS(openssl/hmac.h)
+        if test -z "${HASH_LIBS}"; then
+          HASH_LIBS="-lcrypto"
+        fi
+        if test -z "${HASH_CFLAGS}"; then
+          HASH_CFLAGS=""
+        fi
+        report_hash="OpenSSL"
+        PC_LIB="$PC_LIB${HASH_LIBS} "
+        AC_MSG_NOTICE([
 
     NOTE: OpenSSL is not compatible with GPL applications.
     Even if only linked with GPL code you are not allowed to distibute your app.
@@ -191,7 +196,9 @@ AS_IF([test "${enable_builtinhash}" = "yes"], [
     future versions of liboauth will default to the Mozilla NSS.
      
     see http://people.gnome.org/~markmc/openssl-and-the-gpl.html
-    ])
+        ])
+      ]
+    )
   ])
 ])
 
@@ -229,7 +236,6 @@ if test "$PERL" = "no"; then
 fi
 
 # PKGconfig oauth.pc.in
-AC_SUBST(PC_REQ)
 AC_SUBST(PC_LIB)
 
 

--- a/oauth.pc.in
+++ b/oauth.pc.in
@@ -5,7 +5,6 @@ includedir=@includedir@
 
 Name: oauth
 Description: OAuth - server to server secure API authentication  
-Requires.private: @PC_REQ@
 Version: @VERSION@
 Libs: -L${libdir} -loauth
 Libs.private: -lm @PC_LIB@


### PR DESCRIPTION
This is a bit of a nitpick.

With commit b92c53f, linking to other libraries was reduced already. That was about over-linking. However, if the .pc file of NSS and Curl are missing, pkg-config still gives an error, even with `Requires.private`. This is [not going to be changed …](https://gitlab.freedesktop.org/pkg-config/pkg-config/-/issues/7). Consequently, in in [Debian](https://packages.debian.org/search?keywords=liboauth-dev)/[Ubuntu](https://packages.ubuntu.com/search?keywords=liboauth-dev), the -dev package has to depend on the -dev packages of NSS and Curl; it over-depends.

One approach would be for the Debian package maintainer to remove `Requires.private` from the .pc file. Because the build system was easy to change, I opted to remove `Requires.private` upstream, here in liboauth.